### PR TITLE
Prevent crashes when some endpoints don't return 200

### DIFF
--- a/dgg-utilities.user.js
+++ b/dgg-utilities.user.js
@@ -1729,12 +1729,12 @@ function injectScript() {
       method: "GET",
       url: "https://vyneer.me/tools/nukes",
       onload: (response) => {
-        let data = JSON.parse(response.response);
         if (DEBUG) {
           data = DEBUG_NUKE_DATA;
         }
         nukes = [];
         if (response.status == 200) {
+          let data = JSON.parse(response.response);
           if (data.length > 0) {
             let nukeAlertButtonTooltip = "";
             data.forEach((entry) => {
@@ -1766,11 +1766,11 @@ function injectScript() {
       method: "GET",
       url: "https://vyneer.me/tools/mutelinks",
       onload: (response) => {
-        let data = JSON.parse(response.response);
         if (DEBUG) {
           data = DEBUG_LINKS_DATA;
         }
         if (response.status == 200) {
+          let data = JSON.parse(response.response);
           if (data[0].status == "on") {
             linksAlertButton.style.display = "inline-flex";
             linksAlertButton.title = `Links mentioning ${data[0].user} WILL get you muted (${data[0].duration}).`;

--- a/dgg-utilities.user.js
+++ b/dgg-utilities.user.js
@@ -1510,10 +1510,14 @@ function injectScript() {
       url: "https://vyneer.me/tools/phrases",
       onload: (response) => {
         let data = JSON.parse(response.response);
-        phrases = [];
-        data.forEach((entry) => {
-          phrases.push(entry);
-        });
+        if (response.status == 200) {
+          phrases = [];
+          data.forEach((entry) => {
+            phrases.push(entry);
+          });
+        } else {
+          console.log(`dgg-utils error, can't get phrases - ${response.status}`);
+        }
       },
     });
   }
@@ -1729,12 +1733,15 @@ function injectScript() {
       method: "GET",
       url: "https://vyneer.me/tools/nukes",
       onload: (response) => {
+        let data = [];
         if (DEBUG) {
           data = DEBUG_NUKE_DATA;
         }
         nukes = [];
         if (response.status == 200) {
-          let data = JSON.parse(response.response);
+          if (!DEBUG) {
+             data = JSON.parse(response.response);
+          }
           if (data.length > 0) {
             let nukeAlertButtonTooltip = "";
             data.forEach((entry) => {
@@ -1766,11 +1773,14 @@ function injectScript() {
       method: "GET",
       url: "https://vyneer.me/tools/mutelinks",
       onload: (response) => {
+        let data = [];
         if (DEBUG) {
           data = DEBUG_LINKS_DATA;
         }
         if (response.status == 200) {
-          let data = JSON.parse(response.response);
+          if (!DEBUG) {
+             data = JSON.parse(response.response);
+          }
           if (data[0].status == "on") {
             linksAlertButton.style.display = "inline-flex";
             linksAlertButton.title = `Links mentioning ${data[0].user} WILL get you muted (${data[0].duration}).`;


### PR DESCRIPTION
PR to prevent a crash when the mutelinks, nukes or phrases don't return a 200 response. 

I also made it so debug data doesn't get overridden when a 200 actually gets returned.


 