### PR TITLE
Refocus the chat input after double clicking a username

### DIFF
--- a/dgg-utilities.user.js
+++ b/dgg-utilities.user.js
@@ -617,6 +617,7 @@ function injectScript() {
     }
 
     textarea.value += `${username} `;
+    textarea.focus();
   }
 
   // creating a double click to copy setting


### PR DESCRIPTION
This is a small addition to the double-click-username-to-copy-to-chat-input feature. After copying a username to the chat input, it seems to make sense to then (re)focus the input.

When you click on the username, you'll lose focus on the chat input. And it seems there is already some aggressive (re)focussing of chat input when you click anywhere else in the chat.