### PR TITLE
Fix duplicate LIVE prepended to page's title

### DIFF
--- a/dgg-utilities.user.js
+++ b/dgg-utilities.user.js
@@ -656,8 +656,8 @@ function injectScript() {
     if (node.textContent === "LIVE") {
       if (!window.parent.document.title.includes("LIVE")) {
         ogtitle = window.parent.document.title;
-      }
-      window.parent.document.title = `LIVE - ${ogtitle}`;
+        window.parent.document.title = `LIVE - ${ogtitle}`;
+      } 
     } else {
       window.parent.document.title = ogtitle;
     }


### PR DESCRIPTION
I noticed that every time chat was refreshed it would prepend another "LIVE" to the page's title.
I believe moving the prepend line of code into the if statement that grabs the ogtitle fixes the issue.

This way, if "LIVE" isn't already in the page's title, grab the og title and then prepend "LIVE". From then on whenever `checkLive` is called, "LIVE" is already in the title so it won't be added again.

### Reproduce
- Load up DGG while live
- Refresh just the chat
- See LIVE get prepended to the page's title twice
<img width="202" alt="Screen Shot 2022-07-14 at 9 29 54 PM" src="https://user-images.githubusercontent.com/6654122/179128665-90327101-e842-4cb6-9ec1-dbef38ecf44b.png">
