### PR TITLE
Add styling to the live pill to not wrap text

### DIFF
--- a/dgg-utilities.user.js
+++ b/dgg-utilities.user.js
@@ -1266,6 +1266,11 @@ function injectScript() {
     }
   });
 
+  // modify the styling of the pill to accommadate any longer youtube channels with spaces in the names
+  if (livePill != undefined) {
+    window.parent.document.getElementById("host-pill-name").style.whiteSpace = 'nowrap';
+  }
+
   let editEmbedPillGroup = document.createElement("div");
   editEmbedPillGroup.className = "form-group checkbox";
   let editEmbedPillLabel = document.createElement("label");


### PR DESCRIPTION
In PR #50 a feature was added to show a YouTube channel's name in the live pill when it's embedded; this introduced poor styling on the live pill for some longer YouTube channel names.

Now, a longer YouTube channel name will show up like this:
<img width="354" alt="bad_pill_ellipsis" src="https://user-images.githubusercontent.com/6654122/195413071-93b7415b-8fd8-4acb-ba76-c145c9259e01.png">

The vanilla DGG styling of the live pill has the settings
```
{
  overflow: 'hidden';
  text-overflow: 'ellipsis';
}
```
but not `white-space: 'nowrap';`
This isn't an issue for vanilla DGG, because twitch channel names & YouTube stream ids don't have spaces in them.

I added a line to the code to add the `white-space: 'nowrap';` styling to the `host-pill-name` span.

Now the same YouTube channel name will show up like this:
<img width="290" alt="correct_pill_ellipsis" src="https://user-images.githubusercontent.com/6654122/195413355-35c837c1-9abd-43ed-b030-a3366a82b306.png">
