### PR TITLE
Fixed bug with live pill observer throwing errors in fullscreen chat

### DIFF
--- a/dgg-utilities.user.js
+++ b/dgg-utilities.user.js
@@ -1282,7 +1282,7 @@ function injectScript() {
   editEmbedPillCheck.checked = config.editEmbedPill;
   editEmbedPillCheck.addEventListener("change", () => {
     config.editEmbedPill = editEmbedPillCheck.checked;
-    if (config.editEmbedPill) {
+    if (config.editEmbedPill && livePill != undefined) {
       pillObserver.observe(livePill, {
         childList: true
       });
@@ -1290,7 +1290,7 @@ function injectScript() {
       pillObserver.disconnect();
     }
   });
-  if (config.editEmbedPill) {
+  if (config.editEmbedPill && livePill != undefined) {
     replaceYoutubePillName();
     pillObserver.observe(livePill, {
       childList: true


### PR DESCRIPTION
I messed up with another bug from that PR #50. I forgot to check to see if the chat was in fullscreen mode or bigscreen mode before attempting to create the observer on the `livePill`, which is undefined in fullscreen mode.

The result was an error is thrown in fullscreen chat, and the utilities settings doesn't load.

I copied this solution, of checking that `livePill`, from the "change title on live" setting.

That's my bad, but this seems to fix it :)