### PR TITLE
Adds a button to toggle between DGG chat and the embedded stream's chat (or YT chat if live)

### DIFF
--- a/dgg-utilities.user.js
+++ b/dgg-utilities.user.js
@@ -689,7 +689,7 @@ function injectScript() {
   const embedChatToggleLabel = "Embed Chat";
   const ytChatToggleLabel = "Youtube Chat";
   let dggChatIFrame;
-  if (livePill) {
+  if (livePill != undefined) {
     dggChatIFrame = window.parent.document.getElementById("chat-wrap").getElementsByTagName("iframe")[0];
   }
   let embedChatIFrame;
@@ -780,7 +780,7 @@ function injectScript() {
   }
 
   function addEmbedChatToggleBtn() {
-    if (!livePill) {
+    if (livePill == undefined) {
       return;
     }
 
@@ -809,12 +809,17 @@ function injectScript() {
       window.parent.document.getElementById("refresh").nextSibling
     );
 
-    // The height styling of the DGG chat's input element will be messed up if the DGG chat isn't visible on when the chat's iframe is refreshed
+    // The height styling of the DGG chat's input element will be messed up if the DGG chat isn't visible when the chat's iframe is refreshed
     // https://github.com/destinygg/chat-gui/blob/78910027663171870a314cc3ab3c066334b72326/assets/chat/js/chat.js#L889
     // So, show the DGG chat before refreshing the iframe
     window.parent.document.getElementById("refresh").addEventListener("click", deactivateEmbedChat);
   }
+
   function removeEmbedChatToggleBtn() {
+    if (livePill == undefined) {
+      return;
+    }
+
     dggChatIFrame.style.display = "block";
     window.parent.document.getElementById("embed-chat-toggle").remove();
     window.parent.document.getElementById("embed-chat-iframe").remove();
@@ -826,7 +831,7 @@ function injectScript() {
   let embedChatGroup = document.createElement("div");
   embedChatGroup.className = "form-group checkbox";
   let embedChatLabel = document.createElement("label");
-  embedChatLabel.innerHTML = "Add button to switch betweeen DGG chat & the currently embedded video's chat";
+  embedChatLabel.innerHTML = "Add button to toggle to the currently embedded video's chat";
   embedChatGroup.appendChild(embedChatLabel);
   let embedChatCheck = document.createElement("input");
   embedChatCheck.name = "doubleClickCopy";

--- a/dgg-utilities.user.js
+++ b/dgg-utilities.user.js
@@ -808,11 +808,18 @@ function injectScript() {
       embedChatToggle,
       window.parent.document.getElementById("refresh").nextSibling
     );
+
+    // The height styling of the DGG chat's input element will be messed up if the DGG chat isn't visible on when the chat's iframe is refreshed
+    // https://github.com/destinygg/chat-gui/blob/78910027663171870a314cc3ab3c066334b72326/assets/chat/js/chat.js#L889
+    // So, show the DGG chat before refreshing the iframe
+    window.parent.document.getElementById("refresh").addEventListener("click", deactivateEmbedChat);
   }
   function removeEmbedChatToggleBtn() {
     dggChatIFrame.style.display = "block";
     window.parent.document.getElementById("embed-chat-toggle").remove();
     window.parent.document.getElementById("embed-chat-iframe").remove();
+
+    window.parent.document.getElementById("refresh").removeEventListener("click", deactivateEmbedChat);
   }
 
   // create a setting to enable the link to switch the embed chat


### PR DESCRIPTION
Adds an option to add a button to toggle between the DGG chat and the chat of whatever stream is currently embedded, or YouTube chat if stream is live.

The button while stream is live or while watching an embed:
<img width="572" alt="yt-chat-toggle-btn" src="https://user-images.githubusercontent.com/6654122/196009177-7e2221f6-828d-41cc-9335-4fcdb5879332.png">

The button while looking at the non-DGG chat (YouTube or Twitch):
<img width="533" alt="dgg-chat-toggle-btn" src="https://user-images.githubusercontent.com/6654122/196009192-631aebea-db44-4a72-98e9-098c5594e75c.png">

The button will switch to the Destiny YouTube chat if the stream is live, or if there's an embed, it'll switch to the embed's chat.
Embed's chat will take priority over the live YouTube chat.

The switch is done by hiding the DGG chat's `iframe` with `display: none;` and appending a new iframe that's either the YouTube chat or Twitch chat.

Obviously this is a larger chunk of code. I've been testing it for a couple of days, but let me know if you think anything should be changed or if it doesn't fit with the rest of the utilities :)

Closes #41 