### PR TITLE
Fix error when localStorage values are null or missing

### DIFF
--- a/dgg-utilities.user.js
+++ b/dgg-utilities.user.js
@@ -709,12 +709,14 @@ function injectScript() {
 
   function isLive() {
     const streamInfo = JSON.parse(localStorage.getItem(STORAGE_STREAM_INFO_KEY));
-    return streamInfo.streams.youtube.live || false;
+
+    return streamInfo && (streamInfo?.streams?.youtube?.live || false);
   }
 
   function isHost() {
     const hostInfo = JSON.parse(localStorage.getItem(STORAGE_HOST_INFO_KEY));
-    return hostInfo.id != null;
+
+    return hostInfo && hostInfo.id != null;
   }
 
   function getYTStreamId() {


### PR DESCRIPTION
I noticed an issue where the `dggApi:hostInfo` value was null in my localStorage, which threw an error from `isHost` and broke the script.

I changed the logic a bit to be a bit more robust in grabbing the `dggApi:hostInfo` and `dggApi:streamInfo` values, i.e. just returning false if the localStorage values are null or missing.

I'm not sure why the values were null in my browser. IDK if the localStorage keys changed, but I figured I'd throw up this PR to at least stop the error from being thrown, in case anyone else was experiencing it :)