### PR TITLE
Multi-stream chat embeds

### DIFF
--- a/dgg-utilities.user.js
+++ b/dgg-utilities.user.js
@@ -930,7 +930,7 @@ function injectScript() {
     }
 
     dggChatIFrame.style.display = "block";
-    window.parent.document.getElementById("embed-chat-toggle").remove();
+    window.parent.document.getElementById("embed-chat-btns-container").remove();
     window.parent.document.getElementById("embed-chat-iframe").remove();
 
     window.parent.document.getElementById("refresh").removeEventListener("click", deactivateEmbedChat);

--- a/dgg-utilities.user.js
+++ b/dgg-utilities.user.js
@@ -756,7 +756,7 @@ function injectScript() {
 
   const embedChatButtonsContainer = document.createElement('div');
   embedChatButtonsContainer.id = 'embed-chat-btns-container';
-  embedChatButtonsContainer.className += 'float-left';
+  embedChatButtonsContainer.className += 'float-start';
   Object.assign(embedChatButtonsContainer.style, {
     'display': 'flex',
     'flex-direction': 'row',
@@ -952,7 +952,7 @@ function injectScript() {
     window.parent.document.getElementById("refresh").addEventListener("click", deactivateEmbedChat);
 
     // observe any changes to the embedded stream iframe (additions or removals of the iframe or modifications to the 'src' attribute)
-    embeddedStreamObserver.observe(window.parent.document.getElementById('stream-wrap'), {childList: true, attributes: true, attributeFilter: ['src']});
+    embeddedStreamObserver.observe(window.parent.document.getElementById('embed'), {childList: true, attributes: true, attributeFilter: ['src']});
   }
 
   function removeEmbedChatToggleBtn() {

--- a/dgg-utilities.user.js
+++ b/dgg-utilities.user.js
@@ -958,6 +958,12 @@ function injectScript() {
 
     // observe any changes to the embedded stream iframe (additions or removals of the iframe or modifications to the 'src' attribute)
     embeddedStreamObserver.observe(window.parent.document.getElementById('embed'), {childList: true, attributes: true, attributeFilter: ['src']});
+    // listen for any storage change events, particularly to the two localStorage keys which indicate the currently lives tream or hosted stream
+    window.addEventListener("storage", (event) => {
+      if (event.key === STORAGE_STREAM_INFO_KEY || event.key === STORAGE_HOST_INFO_KEY) {
+        updateEmbedChatButtons();
+      }
+    });
   }
 
   function removeEmbedChatToggleBtn() {

--- a/dgg-utilities.user.js
+++ b/dgg-utilities.user.js
@@ -687,7 +687,7 @@ function injectScript() {
   doubleClickCopyLabel.prepend(doubleClickCopyCheck);
 
   // =============================================================
-  // Icons and HTML elements for managine the DGG & embedded chats
+  // Icons and HTML elements for managing the DGG & embedded chats
   // =============================================================
 
   const DGG_CHAT_ICON = `
@@ -803,6 +803,19 @@ function injectScript() {
     return match ? match[1] : null
   }
 
+  function getYoutubeHostId() {
+    const hostInfo = JSON.parse(localStorage.getItem(STORAGE_HOST_INFO_KEY));
+    return hostInfo?.platform === 'youtube' ? hostInfo.id : null;
+  }
+  function getTwitchHostId() {
+    const hostInfo = JSON.parse(localStorage.getItem(STORAGE_HOST_INFO_KEY));
+    return hostInfo?.platform === 'twitch' ? hostInfo.id : null;
+  }
+  function getRumbleHostId() {
+    const hostInfo = JSON.parse(localStorage.getItem(STORAGE_HOST_INFO_KEY));
+    return hostInfo?.platform === 'rumble' ? hostInfo.id : null;
+  }
+
   function getYoutubeLiveId() {
     const streamInfo = JSON.parse(localStorage.getItem(STORAGE_STREAM_INFO_KEY));
     return streamInfo?.streams?.youtube?.id;
@@ -813,17 +826,17 @@ function injectScript() {
   }
 
   function getTwitchChatURL() {
-    const twitchEmbedId = getTwitchEmbedId();
+    const twitchEmbedId = getTwitchEmbedId() || getTwitchHostId();
     return twitchEmbedId ? `https://www.twitch.tv/embed/${twitchEmbedId}/chat?parent=www.destiny.gg&darkpopout` : null;
   }
   function getYoutubeChatURL() {
     // if the user is embedding a video while the stream is live, the embedded id will be favored
-    const youtubeEmbedId = getYoutubeEmbedId() || getYoutubeLiveId();
+    const youtubeEmbedId = getYoutubeEmbedId() || getYoutubeLiveId() || getYoutubeHostId();
     return youtubeEmbedId ? `https://www.youtube.com/live_chat?v=${youtubeEmbedId}&embed_domain=www.destiny.gg` : null;
   }
   function getRumbleChatURL() {
     // if the user is embedding a video while the stream is live, the embedded id will be favored
-    const rumbleEmbedId = getRumbleEmbedId() || getRumbleLiveId();
+    let rumbleEmbedId = getRumbleEmbedId() || getRumbleLiveId() || getRumbleHostId();
     if (!rumbleEmbedId) return null;
     // remove the 'v' prefix if present, as it's technically not a part of the rumble embed's id
     if (rumbleEmbedId[0] === 'v') {

--- a/dgg-utilities.user.js
+++ b/dgg-utilities.user.js
@@ -820,13 +820,18 @@ function injectScript() {
     const streamInfo = JSON.parse(localStorage.getItem(STORAGE_STREAM_INFO_KEY));
     return streamInfo?.streams?.youtube?.id;
   }
+  // Copium
+  function getTwitchLiveId() {
+    const streamInfo = JSON.parse(localStorage.getItem(STORAGE_STREAM_INFO_KEY));
+    return streamInfo?.streams?.twitch?.id;
+  }
   function getRumbleLiveId() {
     const streamInfo = JSON.parse(localStorage.getItem(STORAGE_STREAM_INFO_KEY));
     return streamInfo?.streams?.rumble?.id;
   }
 
   function getTwitchChatURL() {
-    const twitchEmbedId = getTwitchEmbedId() || getTwitchHostId();
+    const twitchEmbedId = getTwitchEmbedId() || getTwitchLiveId() || getTwitchHostId();
     return twitchEmbedId ? `https://www.twitch.tv/embed/${twitchEmbedId}/chat?parent=www.destiny.gg&darkpopout` : null;
   }
   function getYoutubeChatURL() {

--- a/dgg-utilities.user.js
+++ b/dgg-utilities.user.js
@@ -778,7 +778,7 @@ function injectScript() {
 
   const YOUTUBE_EMBED_RE = /^#youtube\/(.*)$/
   const TWITCH_EMBED_RE = /^#twitch\/(.*)$/
-  const RUMBLE_EMBED_RE = /^#rumble\/v(.*)$/
+  const RUMBLE_EMBED_RE = /^#rumble\/(.*)$/
 
   const STORAGE_STREAM_INFO_KEY = "dggApi:streamInfo";
   const STORAGE_HOST_INFO_KEY = "dggApi:hosting";
@@ -825,6 +825,10 @@ function injectScript() {
     // if the user is embedding a video while the stream is live, the embedded id will be favored
     const rumbleEmbedId = getRumbleEmbedId() || getRumbleLiveId();
     if (!rumbleEmbedId) return null;
+    // remove the 'v' prefix if present, as it's technically not a part of the rumble embed's id
+    if (rumbleEmbedId[0] === 'v') {
+      rumbleEmbedId = rumbleEmbedId.slice(1);
+    }
 
     // a rumble stream's chat id is the base 10 representation of the embed id (which itself is base 36)
     const chatId = parseInt(rumbleEmbedId, 36);

--- a/dgg-utilities.user.js
+++ b/dgg-utilities.user.js
@@ -686,18 +686,95 @@ function injectScript() {
   }
   doubleClickCopyLabel.prepend(doubleClickCopyCheck);
 
-  // functions to manage switching between DGG chat and the embedded chat
-  const dggChatToggleLabel = "DGG Chat";
-  const embedChatToggleLabel = "Embed Chat";
-  const ytChatToggleLabel = "Youtube Chat";
-  const hostChatToggleLabel = "Host Chat";
-  let dggChatIFrame;
-  if (livePill != undefined) {
-    dggChatIFrame = window.parent.document.getElementById("chat-wrap").getElementsByTagName("iframe")[0];
-  }
-  let embedChatIFrame;
-  let embedChatToggle;
-  let embedChatActive = false;
+  // =============================================================
+  // Icons and HTML elements for managine the DGG & embedded chats
+  // =============================================================
+
+  const DGG_CHAT_ICON = `
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1960 1960" fill="currentColor" style="vertical-align: baseline;">
+    <g>
+        <path d="M0 980 l0 -980 980 0 980 0 0 980 0 980 -980 0 -980 0 0 -980z m1810 615 l0 -185 -117 0 -116 0 -116 123 c-64 67 -142 150 -175 185 l-59 62 291 0 292 0 0 -185z m-597 -30 l187 -194 0 -402 0 -401 -184 -191 -183 -192 -437 -3 -436 -2 0 790 0 790 433 0 433 0 187 -195z m597 -1230 l0 -185 -292 0 -291 0 24 27 c13 15 91 98 173 185 l150 158 118 0 118 0 0 -185z"/>
+        <path d="M670 980 l0 -550 65 0 65 0 0 550 0 550 -65 0 -65 0 0 -550z"/>
+    </g>
+</svg>
+  `;
+  const TWITCH_CHAT_ICON = `
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="2 2 20 21" fill="currentColor" style="vertical-align: baseline;">
+    <path d="M 5.8730469 2 C 5.5530469 2 5.2524531 2.1521094 5.0644531 2.4121094 L 2.1914062 6.375 C 2.0674063 6.546 2 6.7518906 2 6.9628906 L 2 19 C 2 19.552 2.448 20 3 20 L 7 20 L 7 22 C 7 22.552 7.448 23 8 23 L 9.5859375 23 C 9.8509375 23 10.104969 22.895031 10.292969 22.707031 L 12.707031 20.292969 C 12.894031 20.104969 13.149062 20 13.414062 20 L 16.585938 20 C 16.850938 20 17.104969 19.895031 17.292969 19.707031 L 21.707031 15.292969 C 21.895031 15.105969 22 14.850938 22 14.585938 L 22 3 C 22 2.448 21.552 2 21 2 L 5.8730469 2 z M 6 4 L 20 4 L 20 13 L 17 16 L 12 16 L 9 19 L 9 16 L 6 16 L 6 4 z M 12 7 C 11.448 7 11 7.448 11 8 L 11 11 C 11 11.552 11.448 12 12 12 C 12.552 12 13 11.552 13 11 L 13 8 C 13 7.448 12.552 7 12 7 z M 17 7 C 16.448 7 16 7.448 16 8 L 16 11 C 16 11.552 16.448 12 17 12 C 17.552 12 18 11.552 18 11 L 18 8 C 18 7.448 17.552 7 17 7 z"/>
+</svg>
+  `;
+  const YOUTUBE_CHAT_ICON = `
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="2 4 26 22" fill="currentColor" style="vertical-align: baseline;">
+    <path d="M 15 4 C 10.814 4 5.3808594 5.0488281 5.3808594 5.0488281 L 5.3671875 5.0644531 C 3.4606632 5.3693645 2 7.0076245 2 9 L 2 15 L 2 15.001953 L 2 21 L 2 21.001953 A 4 4 0 0 0 5.3769531 24.945312 L 5.3808594 24.951172 C 5.3808594 24.951172 10.814 26.001953 15 26.001953 C 19.186 26.001953 24.619141 24.951172 24.619141 24.951172 L 24.621094 24.949219 A 4 4 0 0 0 28 21.001953 L 28 21 L 28 15.001953 L 28 15 L 28 9 A 4 4 0 0 0 24.623047 5.0546875 L 24.619141 5.0488281 C 24.619141 5.0488281 19.186 4 15 4 z M 12 10.398438 L 20 15 L 12 19.601562 L 12 10.398438 z"/>
+</svg>
+  `;
+  const RUMBLE_CHAT_ICON = `
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="1 0 20 20" fill="currentColor" style="vertical-align: baseline;">
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M13.165 11.292c.843-.617.843-1.809 0-2.442a19.617 19.617 0 00-3.922-2.308 1.624 1.624 0 00-1.419.053 1.54 1.54 0 00-.536.474 1.462 1.462 0 00-.254.656 18.136 18.136 0 00-.13 4.584c.023.233.104.458.234.656s.308.364.518.485a1.614 1.614 0 001.404.1 18.68 18.68 0 004.105-2.25v-.008zm6.304-4.5a4.617 4.617 0 011.393 3.276 4.614 4.614 0 01-1.376 3.282c-3.23 3.241-7.376 5.509-11.93 6.525a4.859 4.859 0 01-3.422-.425 4.53 4.53 0 01-2.187-2.558C.556 12.559.765 7.659 2.104 3.309A4.491 4.491 0 014.177.66 4.834 4.834 0 017.582.11c4.47.983 8.67 3.5 11.887 6.683z" />
+</svg>
+  `;
+  const KICK_CHAT_ICON = `
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="6 5 20 22" fill="currentColor" style="vertical-align: baseline;">
+    <polygon fill-rule="evenodd" points="6.18 4.99 13.61 4.99 13.61 9.9 16 9.9 16 7.38 18.52 7.38 18.52 4.99 25.82 4.99 25.82 12.29 23.43 12.29 23.43 14.8 20.91 14.8 20.91 17.2 23.43 17.2 23.43 19.71 25.82 19.71 25.82 27.01 18.52 27.01 18.52 24.62 16 24.62 16 22.1 13.61 22.1 13.61 27.01 6.18 27.01 6.18 4.99"/>
+</svg>
+  `;
+
+  const EMBED_BUTTON_STYLE= {
+    'display': 'flex',
+    'justify-content': 'center',
+    'align-items': 'center',
+
+    'height': '20px',
+    'width': '20px',
+
+    'margin-right': '5px'
+  };
+
+  const dggChatButton = document.createElement('a');
+  dggChatButton.id = 'dgg-chat-btn';
+  dggChatButton.addEventListener('click', handleDGGChatButtonClick);
+  Object.assign(dggChatButton.style, EMBED_BUTTON_STYLE);
+  dggChatButton.innerHTML = DGG_CHAT_ICON;
+
+  const twitchChatButton = document.createElement('a');
+  twitchChatButton.id = 'twitch-chat-btn';
+  twitchChatButton.addEventListener('click', handleTwitchChatButtonClick);
+  Object.assign(twitchChatButton.style, EMBED_BUTTON_STYLE);
+  twitchChatButton.innerHTML = TWITCH_CHAT_ICON;
+
+  const youtubeChatButton = document.createElement('a');
+  youtubeChatButton.id = 'yt-chat-btn';
+  youtubeChatButton.addEventListener('click', handleYoutubeChatButtonClick);
+  Object.assign(youtubeChatButton.style, EMBED_BUTTON_STYLE);
+  youtubeChatButton.innerHTML = YOUTUBE_CHAT_ICON;
+
+  const rumbleChatButton = document.createElement('a');
+  rumbleChatButton.id = 'rumble-chat-btn';
+  rumbleChatButton.addEventListener('click', handleRumbleChatButtonClick);
+  Object.assign(rumbleChatButton.style, EMBED_BUTTON_STYLE);
+  rumbleChatButton.innerHTML = RUMBLE_CHAT_ICON;
+
+  const embedChatButtonsContainer = document.createElement('div');
+  embedChatButtonsContainer.id = 'embed-chat-btns-container';
+  embedChatButtonsContainer.className += 'float-left';
+  Object.assign(embedChatButtonsContainer.style, {
+    'display': 'flex',
+    'flex-direction': 'row',
+    'justify-content': 'center',
+    'align-items': 'center',
+
+    'height': '100%',
+
+    'color': '#444444'
+  });
+  embedChatButtonsContainer.appendChild(dggChatButton);
+  embedChatButtonsContainer.appendChild(twitchChatButton);
+  embedChatButtonsContainer.appendChild(youtubeChatButton);
+  embedChatButtonsContainer.appendChild(rumbleChatButton);
+
+  // =========================================
+  // Functions for managine the embedded chats 
+  // =========================================
 
   const YOUTUBE_EMBED_RE = /^#youtube\/(.*)$/
   const TWITCH_EMBED_RE = /^#twitch\/(.*)$/
@@ -706,29 +783,183 @@ function injectScript() {
   const STORAGE_STREAM_INFO_KEY = "dggApi:streamInfo";
   const STORAGE_HOST_INFO_KEY = "dggApi:hosting";
 
-  function isEmbed() {
-    return getYTEmbedChatURL() != null ||
-      getTwitchEmbedChatURL() != null ||
-      getRumbleEmbedChatURL() != null;
+  let dggChatIFrame;
+  if (livePill != undefined) {
+    dggChatIFrame = window.parent.document.getElementById("chat-wrap").getElementsByTagName("iframe")[0];
+  }
+  let embedChatIFrame;
+  let embedChatActive = false;
+
+  function getYoutubeEmbedId() {
+    const match = YOUTUBE_EMBED_RE.exec(window.parent.location.hash);
+    return match ? match[1] : null;
+  }
+  function getTwitchEmbedId() {
+    const match = TWITCH_EMBED_RE.exec(window.parent.location.hash);
+    return match ? match[1] : null;
+  }
+  function getRumbleEmbedId() {
+    const match = RUMBLE_EMBED_RE.exec(window.parent.location.hash);
+    return match ? match[1] : null
   }
 
-  function isLive() {
+  function getYoutubeLiveId() {
     const streamInfo = JSON.parse(localStorage.getItem(STORAGE_STREAM_INFO_KEY));
-
-    return streamInfo && (streamInfo?.streams?.youtube?.live || false);
+    return streamInfo?.streams?.youtube?.id;
   }
-
-  function isHost() {
-    const hostInfo = JSON.parse(localStorage.getItem(STORAGE_HOST_INFO_KEY));
-
-    return hostInfo && hostInfo.id != null;
-  }
-
-  function getYTStreamId() {
+  function getRumbleLiveId() {
     const streamInfo = JSON.parse(localStorage.getItem(STORAGE_STREAM_INFO_KEY));
-    return streamInfo.streams.youtube.id;
+    return streamInfo?.streams?.rumble?.id;
   }
 
+  function getTwitchChatURL() {
+    const twitchEmbedId = getTwitchEmbedId();
+    return twitchEmbedId ? `https://www.twitch.tv/embed/${twitchEmbedId}/chat?parent=www.destiny.gg&darkpopout` : null;
+  }
+  function getYoutubeChatURL() {
+    const youtubeEmbedId = getYoutubeEmbedId() || getYoutubeLiveId();
+    return youtubeEmbedId ? `https://www.youtube.com/live_chat?v=${youtubeEmbedId}&embed_domain=www.destiny.gg` : null;
+  }
+  function getRumbleChatURL() {
+    const rumbleEmbedId = getRumbleEmbedId() || getRumbleLiveId();
+    if (!rumbleEmbedId) return null;
+
+    // a rumble stream's chat id is the base 10 representation of the embed id (which itself is base 36)
+    const chatId = parseInt(rumbleEmbedId, 36);
+    return Number.isInteger(chatId) ?
+      `https://rumble.com/chat/popup/${chatId}` :
+      null;
+  }
+
+  /**
+   * updateEmbedChatButtons checks to see what's live or embedded, and adds/removes the corresponding embed chat buttons.
+   * Should be called whenever there's an update that could affect what should be embeddable.
+   */
+  function updateEmbedChatButtons() {
+    // dggChatButton.style.display = embedChatActive ? 'flex' : 'none';
+    twitchChatButton.style.display = getTwitchChatURL() ? 'flex' : 'none';
+    youtubeChatButton.style.display = getYoutubeChatURL() ? 'flex' : 'none';
+    rumbleChatButton.style.display = getRumbleChatURL() ? 'flex' : 'none';
+  }
+
+  function deactivateEmbedChat() {
+    embedChatActive = false;
+
+    embedChatIFrame.style.display = "none";
+    dggChatIFrame.style.display = "block";
+
+    updateEmbedChatButtons();
+  }
+
+  function activateEmbedChat(embedChatURL) {
+    embedChatActive = true;
+
+    // only update the src attribute if it has changed to avoid unnecessary refresh
+    if (embedChatIFrame.getAttribute("src") !== embedChatURL) {
+      embedChatIFrame.setAttribute("src", embedChatURL);
+    }
+
+    dggChatIFrame.style.display = "none";
+    embedChatIFrame.style.display = "block";
+
+    updateEmbedChatButtons();
+  }
+
+  function handleDGGChatButtonClick() {
+    deactivateEmbedChat();
+  }
+  function handleTwitchChatButtonClick() {
+    const twitchChatURL = getTwitchChatURL();
+    if (twitchChatURL != null) {
+      activateEmbedChat(twitchChatURL);
+    }
+  }
+  function handleYoutubeChatButtonClick() {
+    const youtubeChatURL = getYoutubeChatURL();
+    if (youtubeChatURL != null) {
+      activateEmbedChat(youtubeChatURL);
+    }
+  }
+  function handleRumbleChatButtonClick() {
+    const rumbleChatURL = getRumbleChatURL();
+    if (rumbleChatURL != null) {
+      activateEmbedChat(rumbleChatURL);
+    }
+  }
+
+  // TODO add mutation observers on embeds and going live
+
+  function addEmbedChatToggleBtn() {
+    if (livePill == undefined) {
+      return;
+    }
+
+    if (window.parent.document.getElementById("embed-chat-iframe")) {
+      removeEmbedChatToggleBtn();
+    }
+
+    // add the iframe for the embedded chat
+    embedChatIFrame = document.createElement("iframe");
+    embedChatIFrame.id = "embed-chat-iframe"
+    embedChatIFrame.style.display = "none";
+    embedChatIFrame.setAttribute("seamless", "seamless");
+    dggChatIFrame.parentNode.appendChild(embedChatIFrame);
+
+    // add the link/button for toggling the embedded chat
+    // embedChatToggle = document.createElement("a");
+    // embedChatToggle.id = "embed-chat-toggle";
+    // embedChatToggle.className = "float-left";
+    // embedChatToggle.style.width = "100px";
+    // embedChatToggle.innerHTML = getEmbedChatToggleButtonText();
+//     embedChatToggle = document.createElement('div');
+//     embedChatToggle.id = 'embedded-chats-container';
+//     embedChatToggle.className += 'float-left';
+//     Object.assign(embedChatToggle.style, {
+//       'display': 'flex',
+//       'flex-direction': 'row',
+//       'justify-content': 'center',
+//       'align-items': 'center',
+// 
+//       'height': '100%',
+// 
+//       'color': '#444444'
+//     });
+//     embedChatToggle.innerHTML = `
+// <a style="height: 20px; width: 20px; margin-right: 5px;">${dggChatIcon}</a>
+// <a style="height: 20px; width: 20px; margin-right: 5px;">${twitchChatIcon}</a>
+// <a style="height: 20px; width: 20px; margin-right: 5px;">${youtubeChatIcon}</a>
+// <a style="height: 20px; width: 20px; margin-right: 5px;">${rumbleChatIcon}</a>
+// <a style="height: 20px; width: 20px; margin-right: 5px;">${kickChatIcon}</a>
+//     `;
+// 
+//     embedChatToggle.addEventListener("click", toggleEmbedChat);
+
+    window.parent.document.getElementById("chat-panel-tools").insertBefore(
+      embedChatButtonsContainer,
+      window.parent.document.getElementById("refresh").nextSibling
+    );
+
+    updateEmbedChatButtons();
+
+    // The height styling of the DGG chat's input element will be messed up if the DGG chat isn't visible when the chat's iframe is refreshed
+    // https://github.com/destinygg/chat-gui/blob/78910027663171870a314cc3ab3c066334b72326/assets/chat/js/chat.js#L889
+    // So, show the DGG chat before refreshing the iframe
+    window.parent.document.getElementById("refresh").addEventListener("click", deactivateEmbedChat);
+  }
+
+  function removeEmbedChatToggleBtn() {
+    if (livePill == undefined) {
+      return;
+    }
+
+    dggChatIFrame.style.display = "block";
+    window.parent.document.getElementById("embed-chat-toggle").remove();
+    window.parent.document.getElementById("embed-chat-iframe").remove();
+
+    window.parent.document.getElementById("refresh").removeEventListener("click", deactivateEmbedChat);
+  }
+
+  /*
   function getYTLiveChatURL() {
     if (isLive()) {
       return `https://www.youtube.com/live_chat?v=${getYTStreamId()}&embed_domain=www.destiny.gg`;
@@ -847,54 +1078,7 @@ function injectScript() {
       return;
     }
   }
-
-  function addEmbedChatToggleBtn() {
-    if (livePill == undefined) {
-      return;
-    }
-
-    if (window.parent.document.getElementById("embed-chat-iframe")) {
-      removeEmbedChatToggleBtn();
-    }
-
-    // add the iframe for the embedded chat
-    embedChatIFrame = document.createElement("iframe");
-    embedChatIFrame.id = "embed-chat-iframe"
-    embedChatIFrame.style.display = "none";
-    embedChatIFrame.setAttribute("seamless", "seamless");
-    dggChatIFrame.parentNode.appendChild(embedChatIFrame);
-
-    // add the link/button for toggling the embedded chat
-    embedChatToggle = document.createElement("a");
-    embedChatToggle.id = "embed-chat-toggle";
-    embedChatToggle.className = "float-left";
-    embedChatToggle.style.width = "100px";
-    embedChatToggle.innerHTML = getEmbedChatToggleButtonText();
-
-    embedChatToggle.addEventListener("click", toggleEmbedChat);
-
-    window.parent.document.getElementById("chat-panel-tools").insertBefore(
-      embedChatToggle,
-      window.parent.document.getElementById("refresh").nextSibling
-    );
-
-    // The height styling of the DGG chat's input element will be messed up if the DGG chat isn't visible when the chat's iframe is refreshed
-    // https://github.com/destinygg/chat-gui/blob/78910027663171870a314cc3ab3c066334b72326/assets/chat/js/chat.js#L889
-    // So, show the DGG chat before refreshing the iframe
-    window.parent.document.getElementById("refresh").addEventListener("click", deactivateEmbedChat);
-  }
-
-  function removeEmbedChatToggleBtn() {
-    if (livePill == undefined) {
-      return;
-    }
-
-    dggChatIFrame.style.display = "block";
-    window.parent.document.getElementById("embed-chat-toggle").remove();
-    window.parent.document.getElementById("embed-chat-iframe").remove();
-
-    window.parent.document.getElementById("refresh").removeEventListener("click", deactivateEmbedChat);
-  }
+  */
 
   // create a setting to enable the link to switch the embed chat
   let embedChatGroup = document.createElement("div");

--- a/dgg-utilities.user.js
+++ b/dgg-utilities.user.js
@@ -691,7 +691,7 @@ function injectScript() {
   // =============================================================
 
   const DGG_CHAT_ICON = `
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1960 1960" fill="currentColor" style="vertical-align: baseline;">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1960 1960" fill="currentColor" style="vertical-align: baseline; filter: drop-shadow(1px 1px 1px #000)">
     <g>
         <path d="M0 980 l0 -980 980 0 980 0 0 980 0 980 -980 0 -980 0 0 -980z m1810 615 l0 -185 -117 0 -116 0 -116 123 c-64 67 -142 150 -175 185 l-59 62 291 0 292 0 0 -185z m-597 -30 l187 -194 0 -402 0 -401 -184 -191 -183 -192 -437 -3 -436 -2 0 790 0 790 433 0 433 0 187 -195z m597 -1230 l0 -185 -292 0 -291 0 24 27 c13 15 91 98 173 185 l150 158 118 0 118 0 0 -185z"/>
         <path d="M670 980 l0 -550 65 0 65 0 0 550 0 550 -65 0 -65 0 0 -550z"/>
@@ -699,22 +699,22 @@ function injectScript() {
 </svg>
   `;
   const TWITCH_CHAT_ICON = `
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="2 2 20 21" fill="currentColor" style="vertical-align: baseline;">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="2 2 20 21" fill="currentColor" style="vertical-align: baseline; filter: drop-shadow(1px 1px 1px #000)">
     <path d="M 5.8730469 2 C 5.5530469 2 5.2524531 2.1521094 5.0644531 2.4121094 L 2.1914062 6.375 C 2.0674063 6.546 2 6.7518906 2 6.9628906 L 2 19 C 2 19.552 2.448 20 3 20 L 7 20 L 7 22 C 7 22.552 7.448 23 8 23 L 9.5859375 23 C 9.8509375 23 10.104969 22.895031 10.292969 22.707031 L 12.707031 20.292969 C 12.894031 20.104969 13.149062 20 13.414062 20 L 16.585938 20 C 16.850938 20 17.104969 19.895031 17.292969 19.707031 L 21.707031 15.292969 C 21.895031 15.105969 22 14.850938 22 14.585938 L 22 3 C 22 2.448 21.552 2 21 2 L 5.8730469 2 z M 6 4 L 20 4 L 20 13 L 17 16 L 12 16 L 9 19 L 9 16 L 6 16 L 6 4 z M 12 7 C 11.448 7 11 7.448 11 8 L 11 11 C 11 11.552 11.448 12 12 12 C 12.552 12 13 11.552 13 11 L 13 8 C 13 7.448 12.552 7 12 7 z M 17 7 C 16.448 7 16 7.448 16 8 L 16 11 C 16 11.552 16.448 12 17 12 C 17.552 12 18 11.552 18 11 L 18 8 C 18 7.448 17.552 7 17 7 z"/>
 </svg>
   `;
   const YOUTUBE_CHAT_ICON = `
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="2 4 26 22" fill="currentColor" style="vertical-align: baseline;">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="2 4 26 22" fill="currentColor" style="vertical-align: baseline; filter: drop-shadow(1px 1px 1px #000)">
     <path d="M 15 4 C 10.814 4 5.3808594 5.0488281 5.3808594 5.0488281 L 5.3671875 5.0644531 C 3.4606632 5.3693645 2 7.0076245 2 9 L 2 15 L 2 15.001953 L 2 21 L 2 21.001953 A 4 4 0 0 0 5.3769531 24.945312 L 5.3808594 24.951172 C 5.3808594 24.951172 10.814 26.001953 15 26.001953 C 19.186 26.001953 24.619141 24.951172 24.619141 24.951172 L 24.621094 24.949219 A 4 4 0 0 0 28 21.001953 L 28 21 L 28 15.001953 L 28 15 L 28 9 A 4 4 0 0 0 24.623047 5.0546875 L 24.619141 5.0488281 C 24.619141 5.0488281 19.186 4 15 4 z M 12 10.398438 L 20 15 L 12 19.601562 L 12 10.398438 z"/>
 </svg>
   `;
   const RUMBLE_CHAT_ICON = `
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="1 0 20 20" fill="currentColor" style="vertical-align: baseline;">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="1 0 20 20" fill="currentColor" style="vertical-align: baseline; filter: drop-shadow(1px 1px 1px #000)">
     <path fill-rule="evenodd" clip-rule="evenodd" d="M13.165 11.292c.843-.617.843-1.809 0-2.442a19.617 19.617 0 00-3.922-2.308 1.624 1.624 0 00-1.419.053 1.54 1.54 0 00-.536.474 1.462 1.462 0 00-.254.656 18.136 18.136 0 00-.13 4.584c.023.233.104.458.234.656s.308.364.518.485a1.614 1.614 0 001.404.1 18.68 18.68 0 004.105-2.25v-.008zm6.304-4.5a4.617 4.617 0 011.393 3.276 4.614 4.614 0 01-1.376 3.282c-3.23 3.241-7.376 5.509-11.93 6.525a4.859 4.859 0 01-3.422-.425 4.53 4.53 0 01-2.187-2.558C.556 12.559.765 7.659 2.104 3.309A4.491 4.491 0 014.177.66 4.834 4.834 0 017.582.11c4.47.983 8.67 3.5 11.887 6.683z" />
 </svg>
   `;
   const KICK_CHAT_ICON = `
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="6 5 20 22" fill="currentColor" style="vertical-align: baseline;">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="6 5 20 22" fill="currentColor" style="vertical-align: baseline; filter: drop-shadow(1px 1px 1px #000)">
     <polygon fill-rule="evenodd" points="6.18 4.99 13.61 4.99 13.61 9.9 16 9.9 16 7.38 18.52 7.38 18.52 4.99 25.82 4.99 25.82 12.29 23.43 12.29 23.43 14.8 20.91 14.8 20.91 17.2 23.43 17.2 23.43 19.71 25.82 19.71 25.82 27.01 18.52 27.01 18.52 24.62 16 24.62 16 22.1 13.61 22.1 13.61 27.01 6.18 27.01 6.18 4.99"/>
 </svg>
   `;

--- a/dgg-utilities.user.js
+++ b/dgg-utilities.user.js
@@ -724,8 +724,8 @@ function injectScript() {
     'justify-content': 'center',
     'align-items': 'center',
 
-    'height': '20px',
-    'width': '20px',
+    'height': '15px',
+    'width': '15px',
 
     'margin-right': '5px'
   };
@@ -773,7 +773,7 @@ function injectScript() {
   embedChatButtonsContainer.appendChild(rumbleChatButton);
 
   // =========================================
-  // Functions for managine the embedded chats 
+  // Functions for managing the embedded chats 
   // =========================================
 
   const YOUTUBE_EMBED_RE = /^#youtube\/(.*)$/
@@ -817,10 +817,12 @@ function injectScript() {
     return twitchEmbedId ? `https://www.twitch.tv/embed/${twitchEmbedId}/chat?parent=www.destiny.gg&darkpopout` : null;
   }
   function getYoutubeChatURL() {
+    // if the user is embedding a video while the stream is live, the embedded id will be favored
     const youtubeEmbedId = getYoutubeEmbedId() || getYoutubeLiveId();
     return youtubeEmbedId ? `https://www.youtube.com/live_chat?v=${youtubeEmbedId}&embed_domain=www.destiny.gg` : null;
   }
   function getRumbleChatURL() {
+    // if the user is embedding a video while the stream is live, the embedded id will be favored
     const rumbleEmbedId = getRumbleEmbedId() || getRumbleLiveId();
     if (!rumbleEmbedId) return null;
 
@@ -889,6 +891,10 @@ function injectScript() {
 
   // TODO add mutation observers on embeds and going live
 
+  // =========================================================================================
+  // Logic for the embedded chat settings, and functions for enabling or disabling the feature
+  // =========================================================================================
+
   function addEmbedChatToggleBtn() {
     if (livePill == undefined) {
       return;
@@ -904,35 +910,6 @@ function injectScript() {
     embedChatIFrame.style.display = "none";
     embedChatIFrame.setAttribute("seamless", "seamless");
     dggChatIFrame.parentNode.appendChild(embedChatIFrame);
-
-    // add the link/button for toggling the embedded chat
-    // embedChatToggle = document.createElement("a");
-    // embedChatToggle.id = "embed-chat-toggle";
-    // embedChatToggle.className = "float-left";
-    // embedChatToggle.style.width = "100px";
-    // embedChatToggle.innerHTML = getEmbedChatToggleButtonText();
-//     embedChatToggle = document.createElement('div');
-//     embedChatToggle.id = 'embedded-chats-container';
-//     embedChatToggle.className += 'float-left';
-//     Object.assign(embedChatToggle.style, {
-//       'display': 'flex',
-//       'flex-direction': 'row',
-//       'justify-content': 'center',
-//       'align-items': 'center',
-// 
-//       'height': '100%',
-// 
-//       'color': '#444444'
-//     });
-//     embedChatToggle.innerHTML = `
-// <a style="height: 20px; width: 20px; margin-right: 5px;">${dggChatIcon}</a>
-// <a style="height: 20px; width: 20px; margin-right: 5px;">${twitchChatIcon}</a>
-// <a style="height: 20px; width: 20px; margin-right: 5px;">${youtubeChatIcon}</a>
-// <a style="height: 20px; width: 20px; margin-right: 5px;">${rumbleChatIcon}</a>
-// <a style="height: 20px; width: 20px; margin-right: 5px;">${kickChatIcon}</a>
-//     `;
-// 
-//     embedChatToggle.addEventListener("click", toggleEmbedChat);
 
     window.parent.document.getElementById("chat-panel-tools").insertBefore(
       embedChatButtonsContainer,
@@ -958,127 +935,6 @@ function injectScript() {
 
     window.parent.document.getElementById("refresh").removeEventListener("click", deactivateEmbedChat);
   }
-
-  /*
-  function getYTLiveChatURL() {
-    if (isLive()) {
-      return `https://www.youtube.com/live_chat?v=${getYTStreamId()}&embed_domain=www.destiny.gg`;
-    }
-
-    return null;
-  }
-
-  function getHostChatURL() {
-    if (isHost()) {
-      const hostInfo = JSON.parse(localStorage.getItem(STORAGE_HOST_INFO_KEY));
-
-      switch(hostInfo.platform) {
-        case 'youtube':
-          return `https://www.youtube.com/live_chat?v=${hostInfo.id}&embed_domain=www.destiny.gg`;
-        case 'twitch':
-          return `https://www.twitch.tv/embed/${hostInfo.id}/chat?parent=www.destiny.gg&darkpopout`;
-      }
-    }
-  }
-
-  function getYTEmbedChatURL() {
-    const match = YOUTUBE_EMBED_RE.exec(window.parent.location.hash);
-    return match ?
-      `https://www.youtube.com/live_chat?v=${match[1]}&embed_domain=www.destiny.gg` :
-      null;
-  }
-
-  function getTwitchEmbedChatURL() {
-    const match = TWITCH_EMBED_RE.exec(window.parent.location.hash);
-    return match ?
-      `https://www.twitch.tv/embed/${match[1]}/chat?parent=www.destiny.gg&darkpopout` :
-      null;
-  }
-
-  function getRumbleEmbedChatURL() {
-    const embedIdMatch = RUMBLE_EMBED_RE.exec(window.parent.location.hash);
-    if (!embedIdMatch) return null;
-    const embedId = embedIdMatch[1];
-
-    // a rumble stream's chat id is the base 10 representation of the embed id (which itself is base 36)
-    const chatId = parseInt(embedId, 36);
-    return Number.isInteger(chatId) ?
-      `https://rumble.com/chat/popup/${chatId}` :
-      null;
-  }
-
-  function getEmbedChatToggleButtonText() {
-    if (isEmbed()) {
-      return embedChatToggleLabel;
-    } else if (isLive()) {
-      return ytChatToggleLabel;
-    } else if (isHost()) {
-      return hostChatToggleLabel;
-    }
-
-    return embedChatToggleLabel;
-  }
-
-  function activateEmbedChat(embedChatURL) {
-    embedChatActive = true;
-
-    // only update the src attribute if it has changed to avoid unnecessary refresh
-    if (embedChatIFrame.getAttribute("src") !== embedChatURL) {
-      embedChatIFrame.setAttribute("src", embedChatURL);
-    }
-
-    dggChatIFrame.style.display = "none";
-    embedChatIFrame.style.display = "block";
-
-    embedChatToggle.innerHTML = dggChatToggleLabel;
-  }
-
-  function deactivateEmbedChat() {
-    embedChatActive = false;
-
-    embedChatIFrame.style.display = "none";
-    dggChatIFrame.style.display = "block";
-
-    embedChatToggle.innerHTML = getEmbedChatToggleButtonText();
-  }
-
-  function toggleEmbedChat() {
-    if (embedChatActive) {
-      deactivateEmbedChat();
-      return;
-    }
-
-    const ytEmbedChatURL = getYTEmbedChatURL();
-    if (ytEmbedChatURL) {
-      activateEmbedChat(ytEmbedChatURL);
-      return;
-    }
-
-    const twitchEmbedChatURL = getTwitchEmbedChatURL();
-    if (twitchEmbedChatURL) {
-      activateEmbedChat(twitchEmbedChatURL);
-      return;
-    }
-
-    const rumbleEmbedChatURL = getRumbleEmbedChatURL();
-    if (rumbleEmbedChatURL) {
-      activateEmbedChat(rumbleEmbedChatURL);
-      return;
-    }
-
-    const ytLiveChatURL = getYTLiveChatURL();
-    if (ytLiveChatURL) {
-      activateEmbedChat(ytLiveChatURL);
-      return;
-    }
-
-    const hostChatURL = getHostChatURL();
-    if (hostChatURL) {
-      activateEmbedChat(hostChatURL);
-      return;
-    }
-  }
-  */
 
   // create a setting to enable the link to switch the embed chat
   let embedChatGroup = document.createElement("div");


### PR DESCRIPTION
https://user-images.githubusercontent.com/6654122/226411282-c73e41bc-88fa-4ea2-99bf-baf0130231d4.mov

Changed the embed chat toggle button to be multiple buttons for whatever platform's chats are currently embeddable.

There is code to detect if there are multiple live streams on DGG itself, like what happened with Twitch & Youtube.
Rumble isn't automatically embedded though, so I haven't tested that detection yet. Right now you would have to manually embed the rumble stream while YT is live to see 3 chat embed buttons at once.

I also added a mutation observer for when the iframe for the embedded stream is added, removed, or altered, to update the appropriate buttons. Those icons should be automatically added/removed whenever you embed something or stream goes live.

In the recording, if you embed rumble, and the stream is live on YT, my code should detect both and you can embed either. You just have to manually embed Rumble, otherwise it's just DGG and YT chats.


All the buttons shouldn't normally show up. This is just to show how they look.
<img width="430" alt="Screenshot 2023-03-20 at 12 47 05 PM" src="https://user-images.githubusercontent.com/6654122/226411215-20380753-2882-4d82-befe-40f4df1d8ae4.png">