### PR TITLE
Increased flair check range up to 100 for new flairs

### DIFF
--- a/dgg-utilities.user.js
+++ b/dgg-utilities.user.js
@@ -1526,10 +1526,10 @@ function injectScript() {
 
   // creating hide invidual flairs setting
   const flairs = getAllFlairIds();
-  // creates flair1-flair50
+  // creates flair1-flair100
   function getAllFlairIds() {
     const flairIds = [];
-    for (let i = 1; i <= 50; i++) {
+    for (let i = 1; i <= 100; i++) {
       flairIds.push(`flair${i}`);
     }
     // Add other flair names


### PR DESCRIPTION
New flairs were added, like flair58 for new users. For the hide flairs options, we try loading flairs 1-50 and remove any that don't have any CSS rules applied to them for a background image. This increases the range to 1-100 to include for recent new flairs.