### PR TITLE
Exclude whispers from phrase detection

### DIFF
--- a/dgg-utilities.user.js
+++ b/dgg-utilities.user.js
@@ -2321,12 +2321,8 @@ function injectScript() {
       let resultNukes;
       let result;
 
-      // exclude whispers sent using slash commands 
-      if(text.startsWith("/w ") || text.startsWith("/whisper ")){
-        return false;
-      }
-      // exclude if the main chat window is inactive
-      if(!$('#chat-windows-select span[title="Destiny GG"].active').length){
+      // exclude whispers sent using slash commands or when the main chatbox is inactive
+      if(text.startsWith("/w ") || text.startsWith("/whisper ") || !$('#chat-windows-select span[title="Destiny GG"].active').length){
         return false;
       }
 

--- a/dgg-utilities.user.js
+++ b/dgg-utilities.user.js
@@ -2319,17 +2319,32 @@ function injectScript() {
   const windowObserver = new MutationObserver((mutations) => {
     for (let mutation of mutations) {
       if (mutation.type === 'childList') {
-        if (document.querySelector("#chat-windows-select span[title=\"Destiny GG\"].active")) {
+        mutation.addedNodes.forEach(node => {
+          if (node.classList.contains('win-main')) {
+            dggIsActive = node.classList.contains('active');
+            if (!dggIsActive) {
+              foundPhraseOrNuke = false;
+              if (textarea.style.backgroundColor != "") {
+                textarea.style.backgroundColor = "";
+              }
+              if (config.preventEnter) {
+                sendAnywayButton.style.display = "none";
+              }
+            }
+          }
+        })
+      } else {
+        if (mutation.target.style.display == 'none') {
           dggIsActive = true;
-        } else {
-          dggIsActive = false;
         }
       }
+      textScanner({});
     }
   });
 
   windowObserver.observe(chatwindowselector, { 
-    childList: true 
+    childList: true,
+    attributes: true,
   });
 
   function textScanner(event) {
@@ -2343,7 +2358,7 @@ function injectScript() {
       let result;
 
       // exclude whispers sent using slash commands or when the main chat window is inactive
-      if (text.startsWith("/w ") || text.startsWith("/whisper ") || !dggIsActive) {
+      if (text.startsWith("/w ") || text.startsWith("/whisper ") || text.startsWith("/msg ") || text.startsWith ("/message ") || text.startsWith("/notify ") || text.startsWith("/tell ")|| !dggIsActive) {
         return false;
       }
 

--- a/dgg-utilities.user.js
+++ b/dgg-utilities.user.js
@@ -2310,11 +2310,12 @@ function injectScript() {
   }
 
   getPhrases();
-  
+ 
   function textScanner(event) {
     // ensure we dont fire on random empty keypresses
     if (!(event.code == "ControlLeft" || event.code == "ControlRight" || event.code == "AltLeft" || event.code == "AltRight" || event.code == "ShiftLeft" || event.code == "ShiftRight" || event.code == "MetaLeft" || event.code == "MetaRight")) {
       let text = textarea.value.toLowerCase();
+      let chatwindow = document.querySelector("#chat-windows-select span[title=\"Destiny GG\"].active")
       let resultCustom;
       let resultCustomSoft;
       let resultLinks;
@@ -2322,7 +2323,7 @@ function injectScript() {
       let result;
 
       // exclude whispers sent using slash commands or when the main chatbox is inactive
-      if (text.startsWith("/w ") || text.startsWith("/whisper ") || !$('#chat-windows-select span[title="Destiny GG"].active').length){
+      if (text.startsWith("/w ") || text.startsWith("/whisper ") || !chatwindow) {
         return false;
       }
 

--- a/dgg-utilities.user.js
+++ b/dgg-utilities.user.js
@@ -2322,7 +2322,7 @@ function injectScript() {
       let result;
 
       // exclude whispers sent using slash commands or when the main chatbox is inactive
-      if(text.startsWith("/w ") || text.startsWith("/whisper ") || !$('#chat-windows-select span[title="Destiny GG"].active').length){
+      if (text.startsWith("/w ") || text.startsWith("/whisper ") || !$('#chat-windows-select span[title="Destiny GG"].active').length){
         return false;
       }
 

--- a/dgg-utilities.user.js
+++ b/dgg-utilities.user.js
@@ -2321,6 +2321,15 @@ function injectScript() {
       let resultNukes;
       let result;
 
+      // exclude whispers sent using slash commands 
+      if(text.startsWith("/w ") || text.startsWith("/whisper ")){
+        return false;
+      }
+      // exclude if the main chat window is inactive
+      if(!$('#chat-windows-select span[title="Destiny GG"].active').length){
+        return false;
+      }
+
       if (phrases.length > 0) {
         for (let entry of phrases) {
           if (typeof(entry) === 'string') {

--- a/dgg-utilities.user.js
+++ b/dgg-utilities.user.js
@@ -2310,20 +2310,40 @@ function injectScript() {
   }
 
   getPhrases();
- 
+  
+  // when no whisper tabs are opened, the chat window selector has no children
+  const chatwindowselector = document.querySelector("#chat-windows-select");
+  let dggIsActive = true;
+  
+  // create an observer that will fire when the chat window selector is updated
+  const windowObserver = new MutationObserver((mutations) => {
+    for (let mutation of mutations) {
+      if (mutation.type === 'childList') {
+        if (document.querySelector("#chat-windows-select span[title=\"Destiny GG\"].active")) {
+          dggIsActive = true;
+        } else {
+          dggIsActive = false;
+        }
+      }
+    }
+  });
+
+  windowObserver.observe(chatwindowselector, { 
+    childList: true 
+  });
+
   function textScanner(event) {
     // ensure we dont fire on random empty keypresses
     if (!(event.code == "ControlLeft" || event.code == "ControlRight" || event.code == "AltLeft" || event.code == "AltRight" || event.code == "ShiftLeft" || event.code == "ShiftRight" || event.code == "MetaLeft" || event.code == "MetaRight")) {
       let text = textarea.value.toLowerCase();
-      let chatwindow = document.querySelector("#chat-windows-select span[title=\"Destiny GG\"].active")
       let resultCustom;
       let resultCustomSoft;
       let resultLinks;
       let resultNukes;
       let result;
 
-      // exclude whispers sent using slash commands or when the main chatbox is inactive
-      if (text.startsWith("/w ") || text.startsWith("/whisper ") || !chatwindow) {
+      // exclude whispers sent using slash commands or when the main chat window is inactive
+      if (text.startsWith("/w ") || text.startsWith("/whisper ") || !dggIsActive) {
         return false;
       }
 


### PR DESCRIPTION
closes #44  
checks if either `/w` or `/whipser` is used, or if you're not in the main chat tab and kicks you out of the `textscanner` function, preventing phrases, mutelinks, nukes, and custom phrases from activating. seems to work fine in my limited testing.

this is either a super elegant solution or absolutely terrible i can't quite tell.